### PR TITLE
Fixed utf8proc.h for vxWorks 6.6, possibly earlier.

### DIFF
--- a/supportApp/netCDFSrc/inc/utf8proc.h
+++ b/supportApp/netCDFSrc/inc/utf8proc.h
@@ -65,12 +65,12 @@
 #else
 # if ! HAVE__BOOL
 #  ifdef __cplusplus
-typedef bool _Bool;
+typedef bool utf8proc_bool;
 #  else
-typedef unsigned char _Bool;
+typedef unsigned char utf8proc_bool;
 #  endif
 # endif
-# define bool _Bool
+# define bool utf8proc_bool
 # define false 0
 # define true 1
 # define __bool_true_false_are_defined 1

--- a/supportApp/netCDFSrc/os/vxWorks/config.h
+++ b/supportApp/netCDFSrc/os/vxWorks/config.h
@@ -180,7 +180,7 @@
 #define HAVE_STDARG_H 1
 
 /* Define to 1 if stdbool.h conforms to C99. */
-#if defined(vxWorks) && defined(_WRS_VXWORKS_MAJOR) && (_WRS_VXWORKS_MAJOR >= 6) && (_WRS_VXWORKS_MINOR >= 8)
+#if defined(vxWorks) && defined(_WRS_VXWORKS_MAJOR) && (_WRS_VXWORKS_MAJOR >= 6) && (_WRS_VXWORKS_MINOR >= 6)
   #define HAVE_STDBOOL_H 1
 #endif
 


### PR DESCRIPTION
Root cause of "error: two or more data types in declaration specifiers"
is that the vxWorks g++ is treating _Bool as something other than just an identifier.
Not sure what, as it doesn't appear in predefined compiler macros or pre-processed output, 
but just changing the _Bool identifier to utf8proc_bool fixes it.
I also found I could avoid the entire problem for vxWorks 6.6 by setting HAVE_STDBOOL_H
so rolled back the version test from 6.8 to 6.6.
Either fix is sufficient for vxWorks 6.6, and hopefully together will cover most vxWorks versions.