### PR TITLE
Modified xml2Src/nanohttp.c (and xml2Src/nanohttp.h) to parse, and to…

### DIFF
--- a/supportApp/GraphicsMagickSrc/Magick++/lib/Image.cpp
+++ b/supportApp/GraphicsMagickSrc/Magick++/lib/Image.cpp
@@ -1540,7 +1540,9 @@ void Magick::Image::read ( const std::string &imageSpec_ )
   ExceptionInfo exceptionInfo;
   GetExceptionInfo( &exceptionInfo );
   MagickLib::Image* image =
-    ReadImage( imageInfo(), &exceptionInfo );
+    ReadImage(imageInfo(), &exceptionInfo );
+  if ((image && image->client_data) && (imageInfo()->file == NULL))
+	  imageInfo()->file = static_cast<FILE*>(image->client_data);
 
   // Ensure that multiple image frames were not read.
   if ( image && image->next )

--- a/supportApp/GraphicsMagickSrc/coders/url.c
+++ b/supportApp/GraphicsMagickSrc/coders/url.c
@@ -126,7 +126,7 @@ static Image *ReadURLImage(const ImageInfo *image_info,ExceptionInfo *exception)
     *clone_info;
 
   void
-    *context;
+    *context = NULL;
 
   ConfirmAccessMode
     access_mode=UndefinedConfirmAccessMode;
@@ -180,14 +180,29 @@ static Image *ReadURLImage(const ImageInfo *image_info,ExceptionInfo *exception)
             bytes;
 
           type=(char *) NULL;
-          context=xmlNanoHTTPOpen(filename,&type);
+		  if (!image_info->file)
+			context=xmlNanoHTTPOpen(filename,&type);
+		  else
+		  {
+			context=image_info->file;
+			clone_info->file = NULL;
+		  }
           if (context != (void *) NULL)
             {
               while ((bytes=xmlNanoHTTPRead(context,buffer,MaxBufferExtent)) > 0)
+			  {
                 (void) fwrite(buffer,bytes,1,file);
-              xmlNanoHTTPClose(context);
-              xmlFree(type);
-              xmlNanoHTTPCleanup();
+				if ((xmlNanoHTTPFrameState(context) == Complete) || (xmlNanoHTTPFrameState(context) == Error))
+					break;
+			  }
+			  if (type)
+				xmlFree(type);
+			  if (!xmlNanoHTTPStreaming(context))
+			  {
+				xmlNanoHTTPClose(context);
+				xmlNanoHTTPCleanup();
+				context = NULL;
+			  }
             }
         }
       else if (LocaleCompare(clone_info->magick,"ftp") == 0)
@@ -211,7 +226,10 @@ static Image *ReadURLImage(const ImageInfo *image_info,ExceptionInfo *exception)
       else
         {
           *clone_info->magick='\0';
-          image=ReadImage(clone_info,exception);
+		  if (xmlNanoHTTPFrameState(context) != Error)
+			image=ReadImage(clone_info,exception);
+		  if ((context) && (image))
+			image->client_data = context;
         }
       (void) LiberateTemporaryFile(clone_info->filename);
     }

--- a/supportApp/xml2Src/os/default/libxml/nanohttp.h
+++ b/supportApp/xml2Src/os/default/libxml/nanohttp.h
@@ -18,6 +18,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef enum {
+	Idle, FoundStart, Complete, Error
+} xmlNanoFrameStates;
+
 XMLPUBFUN void XMLCALL
 	xmlNanoHTTPInit		(void);
 XMLPUBFUN void XMLCALL
@@ -66,6 +71,10 @@ XMLPUBFUN int XMLCALL
 	xmlNanoHTTPRead		(void *ctx,
 				 void *dest,
 				 int len);
+XMLPUBFUN xmlNanoFrameStates XMLCALL
+	xmlNanoHTTPFrameState	(void *ctx);
+XMLPUBFUN int XMLCALL
+	xmlNanoHTTPStreaming	(void *ctx);
 #ifdef LIBXML_OUTPUT_ENABLED
 XMLPUBFUN int XMLCALL
 	xmlNanoHTTPSave		(void *ctxt,


### PR DESCRIPTION
… paginate, mjpeg streams.

coders/url.c also needs to paginate the stream. The open socket connection mustn't be closed & re-opened per frame, in this case, instead the handle is passed to the caller (Magic++/Image.cpp), which takes ownership. I wasn't able to identify a better approach to this.

Existing use of single-frame acquisition is not affected by these changes.

I've tested this on Windows7, Ubuntu 18.04 and Scientific Linux 7.3.

I've tested it with 2 cameras I have here, and a selection of publicly accessible Internet cameras.