### PR TITLE
to fix redefined macro warning on vxWorks

### DIFF
--- a/supportApp/jpegSrc/README.epics
+++ b/supportApp/jpegSrc/README.epics
@@ -5,7 +5,7 @@ The following source files were modified.
 
 jmorecfg.h
   Windows version define EXTERN and GLOBAL appropriately for DLLs
-  vxWorks version don't redefine UINT8, UINT16, INT16, INT32 
+  vxWorks version don't redefine UINT8, UINT16, INT16, INT32 and replace LOCAL macro
 
 Makefile  
   This is completely new.

--- a/supportApp/jpegSrc/os/vxWorks/jmorecfg.h
+++ b/supportApp/jpegSrc/os/vxWorks/jmorecfg.h
@@ -241,7 +241,10 @@ typedef unsigned int JDIMENSION;
 /* a function called through method pointers: */
 #define METHODDEF(type)		static type
 /* a function used only in its module: */
+#ifdef LOCAL
+#undef LOCAL
 #define LOCAL(type)		static type
+#endif
 /* a function referenced thru EXTERNs: */
 #define GLOBAL(type)		type
 /* a reference to a GLOBAL function: */


### PR DESCRIPTION
In both tornado 2.2 and vxWorks 6.7, the macro LOCAL is defined, in a different form. 
``
#define LOCAL   static
``
So it cannot be simply commented out.