### PR TITLE
fix for building GraphicsMagick and netCDF on macOS

### DIFF
--- a/supportApp/GraphicsMagickSrc/magick/Makefile
+++ b/supportApp/GraphicsMagickSrc/magick/Makefile
@@ -38,6 +38,7 @@ ifeq ($(WITH_GRAPHICSMAGICK),YES)
     INSTALL_INCLUDE           = $(INSTALL_LOCATION)/include/magick
     INC += magick_config.h
     INC += magick_config_Win32.h
+    INC += magick_config_Darwin.h
     INC += magick_config_Linux.h
     INC += api.h
     INC += enum_strings.h

--- a/supportApp/GraphicsMagickSrc/magick/magick_config.h
+++ b/supportApp/GraphicsMagickSrc/magick/magick_config.h
@@ -1,5 +1,7 @@
 #if defined(WIN32) || defined(WIN64)
 #include "magick_config_Win32.h"
+#elif defined(__APPLE__)
+#include "magick_config_Darwin.h"
 #else
 #include "magick_config_Linux.h"
 #endif

--- a/supportApp/GraphicsMagickSrc/magick/magick_config_Darwin.h
+++ b/supportApp/GraphicsMagickSrc/magick/magick_config_Darwin.h
@@ -1,0 +1,683 @@
+/* magick/magick_config.h.  Generated from magick_config.h.in by configure.  */
+/* magick/magick_config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* Define if coders and filters are to be built as modules. */
+/* #undef BuildMagickModules */
+
+/* Disable OpenMP for algorithms which sometimes run slower */
+#define DisableSlowOpenMP 1
+
+/* Enable broken/dangerous file formats support */
+/* #undef EnableBrokenCoders */
+
+/* C compiler used for compilation */
+#define GM_BUILD_CC "gcc"
+
+/* CFLAGS used for C compilation */
+#define GM_BUILD_CFLAGS "-g -O2 -Wall -D_THREAD_SAFE"
+
+/* arguments passed to configure */
+#define GM_BUILD_CONFIGURE_ARGS "./configure  '--without-x'"
+
+/* CPPFLAGS used for preprocessing */
+#define GM_BUILD_CPPFLAGS "-I/opt/local/include/freetype2 -I/opt/local/include/libxml2"
+
+/* C++ compiler used for compilation */
+#define GM_BUILD_CXX "g++"
+
+/* CXXFLAGS used for C++ compilation */
+#define GM_BUILD_CXXFLAGS "-D_THREAD_SAFE"
+
+/* Host identification triplet */
+#define GM_BUILD_HOST "x86_64-apple-darwin17.7.0"
+
+/* LDFLAGS used for linking */
+#define GM_BUILD_LDFLAGS "-L/opt/local/lib"
+
+/* LIBS used for linking */
+#define GM_BUILD_LIBS "-lfreetype -lbz2 -lxml2 -lz -lm -lpthread"
+
+/* Define if C++ compiler supports __func__ */
+#define HAS_CPP__func__ 1
+
+/* Define if C compiler supports __func__ */
+#define HAS_C__func__ 1
+
+/* Define to 1 if you have the `atoll' function. */
+#define HAVE_ATOLL 1
+
+/* define if bool is a built-in type */
+#define HAVE_BOOL /**/
+
+/* Define to 1 if you have the `clock_getres' function. */
+#define HAVE_CLOCK_GETRES 1
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+
+/* define if the compiler supports const_cast<> */
+#define HAVE_CONST_CAST /**/
+
+/* Define to 1 if you have the `CryptGenRandom' function. */
+/* #undef HAVE_CRYPTGENRANDOM */
+
+/* Define to 1 if you have the `ctime_r' function. */
+#define HAVE_CTIME_R 1
+
+/* Define to 1 if you have the declaration of `pread', and to 0 if you don't.
+   */
+#define HAVE_DECL_PREAD 1
+
+/* Define to 1 if you have the declaration of `pwrite', and to 0 if you don't.
+   */
+#define HAVE_DECL_PWRITE 1
+
+/* Define to 1 if you have the declaration of `strlcpy', and to 0 if you
+   don't. */
+#define HAVE_DECL_STRLCPY 1
+
+/* Define to 1 if you have the declaration of `vsnprintf', and to 0 if you
+   don't. */
+#define HAVE_DECL_VSNPRINTF 1
+
+/* define if the compiler supports default template parameters */
+#define HAVE_DEFAULT_TEMPLATE_PARAMETERS /**/
+
+/* Have a /dev/urandom device for producing random bytes */
+#define HAVE_DEV_URANDOM 1
+
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
+   */
+#define HAVE_DIRENT_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* define if the compiler supports exceptions */
+#define HAVE_EXCEPTIONS /**/
+
+/* define if the compiler supports the explicit keyword */
+#define HAVE_EXPLICIT /**/
+
+/* Define to 1 if you have the `fcntl' function. */
+#define HAVE_FCNTL 1
+
+/* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
+#define HAVE_FSEEKO 1
+
+/* Define to 1 if you have the `fstatvfs' function. */
+#define HAVE_FSTATVFS 1
+
+/* Define to 1 if you have the <ft2build.h> header file. */
+#define HAVE_FT2BUILD_H 1
+
+/* Define to 1 if you have the `ftime' function. */
+#define HAVE_FTIME 1
+
+/* Define to 1 if you have the `getc_unlocked' function. */
+#define HAVE_GETC_UNLOCKED 1
+
+/* Define to 1 if you have the `getexecname' function. */
+/* #undef HAVE_GETEXECNAME */
+
+/* Define to 1 if you have the `getpagesize' function. */
+#define HAVE_GETPAGESIZE 1
+
+/* Define to 1 if you have the `getpid' function. */
+#define HAVE_GETPID 1
+
+/* Define to 1 if you have the `getrlimit' function. */
+#define HAVE_GETRLIMIT 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if you have the <lcms2.h> header file. */
+#define HAVE_LCMS2_H 1
+
+/* Define if you have the <lcms2/lcms2.h> header file. */
+/* #undef HAVE_LCMS2_LCMS2_H */
+
+/* Define to 1 if you have the `lltostr' function. */
+/* #undef HAVE_LLTOSTR */
+
+/* Define to 1 if you have the `localtime_r' function. */
+#define HAVE_LOCALTIME_R 1
+
+/* Define to 1 if the type `long double' works and has more range or precision
+   than `double'. */
+#define HAVE_LONG_DOUBLE_WIDER 1
+
+/* Define to 1 if you have the <machine/param.h> header file. */
+#define HAVE_MACHINE_PARAM_H 1
+
+/* Define to 1 if you have the <mach-o/dyld.h> header file. */
+#define HAVE_MACH_O_DYLD_H 1
+
+/* Define to 1 if you have the `madvise' function. */
+#define HAVE_MADVISE 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have a `mmap' system call which handles coherent file
+   I/O. */
+#define HAVE_MMAP_FILEIO 1
+
+/* define if the compiler supports the mutable keyword */
+#define HAVE_MUTABLE /**/
+
+/* define if the compiler implements namespaces */
+#define HAVE_NAMESPACES /**/
+
+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
+/* #undef HAVE_NDIR_H */
+
+/* define if the compiler accepts the new for scoping rules */
+#define HAVE_NEW_FOR_SCOPING /**/
+
+/* Define to 1 if you have the `pclose' function. */
+#define HAVE_PCLOSE 1
+
+/* Define to 1 if you have the `poll' function. */
+#define HAVE_POLL 1
+
+/* Define to 1 if you have the `popen' function. */
+#define HAVE_POPEN 1
+
+/* Define to 1 if you have the `posix_fadvise' function. */
+/* #undef HAVE_POSIX_FADVISE */
+
+/* Define to 1 if you have the `posix_fallocate' function. */
+/* #undef HAVE_POSIX_FALLOCATE */
+
+/* Define to 1 if you have the `posix_madvise' function. */
+#define HAVE_POSIX_MADVISE 1
+
+/* Define to 1 if you have the `posix_memalign' function. */
+#define HAVE_POSIX_MEMALIGN 1
+
+/* Define to 1 if you have the `posix_spawnp' function. */
+#define HAVE_POSIX_SPAWNP 1
+
+/* Define to 1 if you have the `pread' function. */
+#define HAVE_PREAD 1
+
+/* Define to 1 if you have the <process.h> header file. */
+/* #undef HAVE_PROCESS_H */
+
+/* Define if you have POSIX threads libraries and header files. */
+#define HAVE_PTHREAD 1
+
+/* Define to 1 if you have the `putc_unlocked' function. */
+#define HAVE_PUTC_UNLOCKED 1
+
+/* Define to 1 if you have the `pwrite' function. */
+#define HAVE_PWRITE 1
+
+/* Define to 1 if you have the `qsort_r' function. */
+#define HAVE_QSORT_R 1
+
+/* Define to 1 if you have the `raise' function. */
+#define HAVE_RAISE 1
+
+/* Define to 1 if you have the `rand_r' function. */
+#define HAVE_RAND_R 1
+
+/* Define to 1 if you have the `readdir_r' function. */
+#define HAVE_READDIR_R 1
+
+/* Define to 1 if you have the `readlink' function. */
+#define HAVE_READLINK 1
+
+/* Define to 1 if you have the `realpath' function. */
+#define HAVE_REALPATH 1
+
+/* Define to 1 if you have the `seekdir' function. */
+#define HAVE_SEEKDIR 1
+
+/* Define to 1 if you have the `select' function. */
+#define HAVE_SELECT 1
+
+/* Define to 1 if you have the `setrlimit' function. */
+#define HAVE_SETRLIMIT 1
+
+/* Define to 1 if you have the `sigaction' function. */
+#define HAVE_SIGACTION 1
+
+/* Define to 1 if you have the `sigemptyset' function. */
+#define HAVE_SIGEMPTYSET 1
+
+/* Define to 1 if you have the `spawnvp' function. */
+/* #undef HAVE_SPAWNVP */
+
+/* define if the compiler supports static_cast<> */
+#define HAVE_STATIC_CAST /**/
+
+/* define if the compiler supports ISO C++ standard library */
+#define HAVE_STD /**/
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* define if the compiler supports Standard Template Library */
+#define HAVE_STL /**/
+
+/* Define to 1 if you have the `strerror' function. */
+#define HAVE_STRERROR 1
+
+/* Define to 1 if you have the `strerror_r' function. */
+#define HAVE_STRERROR_R 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strlcat' function. */
+#define HAVE_STRLCAT 1
+
+/* Define to 1 if you have the `strlcpy' function. */
+#define HAVE_STRLCPY 1
+
+/* Define to 1 if you have the `strtoll' function. */
+#define HAVE_STRTOLL 1
+
+/* Define to 1 if you have the <sun_prefetch.h> header file. */
+/* #undef HAVE_SUN_PREFETCH_H */
+
+/* Define to 1 if you have the `sysconf' function. */
+#define HAVE_SYSCONF 1
+
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
+   */
+/* #undef HAVE_SYS_DIR_H */
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#define HAVE_SYS_MMAN_H 1
+
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
+   */
+/* #undef HAVE_SYS_NDIR_H */
+
+/* Define to 1 if you have the <sys/resource.h> header file. */
+#define HAVE_SYS_RESOURCE_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/times.h> header file. */
+#define HAVE_SYS_TIMES_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the `telldir' function. */
+#define HAVE_TELLDIR 1
+
+/* define if the compiler supports basic templates */
+#define HAVE_TEMPLATES /**/
+
+/* Define to 1 if you have the <tiffconf.h> header file. */
+/* #undef HAVE_TIFFCONF_H */
+
+/* Define to 1 if you have the `TIFFIsCODECConfigured' function. */
+/* #undef HAVE_TIFFISCODECCONFIGURED */
+
+/* Define to 1 if you have the `TIFFMergeFieldInfo' function. */
+/* #undef HAVE_TIFFMERGEFIELDINFO */
+
+/* Define to 1 if you have the `TIFFSetErrorHandlerExt' function. */
+/* #undef HAVE_TIFFSETERRORHANDLEREXT */
+
+/* Define to 1 if you have the `TIFFSetTagExtender' function. */
+/* #undef HAVE_TIFFSETTAGEXTENDER */
+
+/* Define to 1 if you have the `TIFFSetWarningHandlerExt' function. */
+/* #undef HAVE_TIFFSETWARNINGHANDLEREXT */
+
+/* Define to 1 if you have the `TIFFSwabArrayOfTriples' function. */
+/* #undef HAVE_TIFFSWABARRAYOFTRIPLES */
+
+/* Define to 1 if you have the `times' function. */
+#define HAVE_TIMES 1
+
+/* Define to 1 if you have the `ulltostr' function. */
+/* #undef HAVE_ULLTOSTR */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `vsnprintf' function. */
+#define HAVE_VSNPRINTF 1
+
+/* Define to 1 if you have the `vsprintf' function. */
+#define HAVE_VSPRINTF 1
+
+/* Define to 1 if you have the <wincrypt.h> header file. */
+/* #undef HAVE_WINCRYPT_H */
+
+/* Define to 1 if you have the `_exit' function. */
+#define HAVE__EXIT 1
+
+/* Define to 1 if you have the `_NSGetExecutablePath' function. */
+#define HAVE__NSGETEXECUTABLEPATH 1
+
+/* Define to 1 if you have the `_pclose' function. */
+/* #undef HAVE__PCLOSE */
+
+/* Define to 1 if you have the `_popen' function. */
+/* #undef HAVE__POPEN */
+
+/* Define if you have the bzip2 library */
+#define HasBZLIB 1
+
+/* Define if you have Display Postscript */
+/* #undef HasDPS */
+
+/* Define if you have FlashPIX library */
+/* #undef HasFPX */
+
+/* Define if you have Ghostscript library */
+/* #undef HasGS */
+
+/* Define if you have JBIG library */
+#define HasJBIG 1
+
+/* Define if you have JPEG version 2 "Jasper" library */
+#define HasJP2 1
+
+/* Define if you have JPEG library */
+#define HasJPEG 1
+
+/* Define if you have LCMS (v2.0 or later) library */
+#define HasLCMS 1
+
+/* Define if using libltdl to support dynamically loadable modules */
+/* #undef HasLTDL */
+
+/* Define if you have lzma compression library */
+/* #undef HasLZMA */
+
+/* Define if you have PNG library */
+#define HasPNG 1
+
+/* X11 server supports shape extension */
+/* #undef HasShape */
+
+/* X11 server supports shared memory extension */
+/* #undef HasSharedMemory */
+
+/* Define if you have TIFF library */
+#define HasTIFF 1
+
+/* Define if you have TRIO vsnprintf replacement library */
+/* #undef HasTRIO */
+
+/* Define if you have FreeType (TrueType font) library */
+#define HasTTF 1
+
+/* Define if you have umem memory allocation library */
+/* #undef HasUMEM */
+
+/* Define if you have WEBP library */
+#define HasWEBP 1
+
+/* Define to use the Windows GDI32 library */
+/* #undef HasWINGDI32 */
+
+/* Define if you have wmflite library */
+/* #undef HasWMFlite */
+
+/* Define if you have X11 library */
+/* #undef HasX11 */
+
+/* Define if you have XML library */
+#define HasXML 1
+
+/* Define if you have zlib compression library */
+#define HasZLIB 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Define to prepend to default font search path. */
+/* #undef MAGICK_FONT_PATH */
+
+/* Command which returns total physical memory in bytes */
+#define MAGICK_PHYSICAL_MEMORY_COMMAND "/usr/sbin/sysctl -n hw.physmem"
+
+/* Target Host CPU */
+#define MAGICK_TARGET_CPU x86_64
+
+/* Target Host OS */
+#define MAGICK_TARGET_OS darwin17.7.0
+
+/* Target Host Vendor */
+#define MAGICK_TARGET_VENDOR apple
+
+/* define if the compiler lacks ios::binary */
+/* #undef MISSING_STD_IOS_BINARY */
+
+/* Directory where executables are installed. */
+#define MagickBinPath "/usr/local/bin/"
+
+/* Location of coder modules */
+#define MagickCoderModulesPath "/usr/local/lib/GraphicsMagick-1.3.25/modules-Q8/coders/"
+
+/* Subdirectory of lib where coder modules are installed */
+#define MagickCoderModulesSubdir "GraphicsMagick-1.3.25/modules-Q8/coders"
+
+/* Location of filter modules */
+#define MagickFilterModulesPath "/usr/local/lib/GraphicsMagick-1.3.25/modules-Q8/filters/"
+
+/* Subdirectory of lib where filter modules are installed */
+#define MagickFilterModulesSubdir "GraphicsMagick-1.3.25/modules-Q8/filters"
+
+/* Directory where architecture-dependent configuration files live. */
+#define MagickLibConfigPath "/usr/local/lib/GraphicsMagick-1.3.25/config/"
+
+/* Subdirectory of lib where architecture-dependent configuration files live.
+   */
+#define MagickLibConfigSubDir "GraphicsMagick-1.3.25/config"
+
+/* Directory where architecture-dependent files live. */
+#define MagickLibPath "/usr/local/lib/GraphicsMagick-1.3.25/"
+
+/* Subdirectory of lib where GraphicsMagick architecture dependent files are
+   installed */
+#define MagickLibSubdir "GraphicsMagick-1.3.25"
+
+/* Directory where architecture-independent configuration files live. */
+#define MagickShareConfigPath "/usr/local/share/GraphicsMagick-1.3.25/config/"
+
+/* Subdirectory of lib where architecture-independent configuration files
+   live. */
+#define MagickShareConfigSubDir "GraphicsMagick-1.3.25/config"
+
+/* Directory where architecture-independent files live. */
+#define MagickSharePath "/usr/local/share/GraphicsMagick-1.3.25/"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME ""
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING ""
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME ""
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION ""
+
+/* Prefix Magick library symbols with a common string. */
+/* #undef PREFIX_MAGICK_SYMBOLS */
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* Number of bits in a pixel Quantum (8/16/32) */
+#define QuantumDepth 8
+
+/* Define as the return type of signal handlers (`int' or `void'). */
+#define RETSIGTYPE void
+
+/* The size of `off_t', as computed by sizeof. */
+#define SIZEOF_OFF_T 8
+
+/* The size of `signed int', as computed by sizeof. */
+#define SIZEOF_SIGNED_INT 4
+
+/* The size of `signed long', as computed by sizeof. */
+#define SIZEOF_SIGNED_LONG 8
+
+/* The size of `signed long long', as computed by sizeof. */
+#define SIZEOF_SIGNED_LONG_LONG 8
+
+/* The size of `signed short', as computed by sizeof. */
+#define SIZEOF_SIGNED_SHORT 2
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T 8
+
+/* The size of `unsigned int', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_INT 4
+
+/* The size of `unsigned int*', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_INTP 8
+
+/* The size of `unsigned long', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_LONG 8
+
+/* The size of `unsigned long long', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_LONG_LONG 8
+
+/* The size of `unsigned short', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_SHORT 2
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
+/* GraphicsMagick is formally installed under prefix */
+#define UseInstalledMagick 1
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Location of X11 configure files */
+#define X11ConfigurePath "X11ConfigurePath"
+
+/* Define to 1 if the X Window System is missing or not being used. */
+#define X_DISPLAY_MISSING 1
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define to 1 to make fseeko visible on some hosts (e.g. glibc 2.2). */
+/* #undef _LARGEFILE_SOURCE */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */
+
+/* Define to 1 if type `char' is unsigned and you are not using gcc.  */
+#ifndef __CHAR_UNSIGNED__
+/* # undef __CHAR_UNSIGNED__ */
+#endif
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef mode_t */
+
+/* Define to `long int' if <sys/types.h> does not define. */
+/* #undef off_t */
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef pid_t */
+
+/* Define to the equivalent of the C99 'restrict' keyword, or to
+   nothing if this is not supported.  Do not define if restrict is
+   supported directly.  */
+#define restrict __restrict
+/* Work around a bug in Sun C++: it does not support _Restrict or
+   __restrict__, even though the corresponding Sun C compiler ends up with
+   "#define restrict _Restrict" or "#define restrict __restrict__" in the
+   previous line.  Perhaps some future version of Sun C++ will work with
+   restrict; if so, hopefully it defines __RESTRICT like Sun C does.  */
+#if defined __SUNPRO_CC && !defined __RESTRICT
+# define _Restrict
+# define __restrict__
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef ssize_t */

--- a/supportApp/GraphicsMagickSrc/magick/magick_config_Linux.h
+++ b/supportApp/GraphicsMagickSrc/magick/magick_config_Linux.h
@@ -393,16 +393,16 @@
 /* #undef HasGS */
 
 /* Define if you have JBIG library */
-/* #undef HasJBIG */
+#define HasJBIG 1
 
 /* Define if you have JPEG version 2 "Jasper" library */
-/* #undef HasJP2 */
+#define HasJP2 1
 
 /* Define if you have JPEG library */
 #define HasJPEG 1
 
 /* Define if you have LCMS (v2.0 or later) library */
-/* #undef HasLCMS */
+#define HasLCMS 1
 
 /* Define if using libltdl to support dynamically loadable modules */
 /* #undef HasLTDL */
@@ -432,7 +432,7 @@
 /* #undef HasUMEM */
 
 /* Define if you have WEBP library */
-/* #undef HasWEBP */
+#define HasWEBP 1
 
 /* Define to use the Windows GDI32 library */
 /* #undef HasWINGDI32 */

--- a/supportApp/GraphicsMagickSrc/magick/magick_config_Linux.h
+++ b/supportApp/GraphicsMagickSrc/magick/magick_config_Linux.h
@@ -140,7 +140,7 @@
 #define HAVE_INTTYPES_H 1
 
 /* Define if you have the <lcms2.h> header file. */
-/* #undef HAVE_LCMS2_H */
+#define HAVE_LCMS2_H 1
 
 /* Define if you have the <lcms2/lcms2.h> header file. */
 /* #undef HAVE_LCMS2_LCMS2_H */

--- a/supportApp/netCDFSrc/os/Darwin/config.h
+++ b/supportApp/netCDFSrc/os/Darwin/config.h
@@ -4,6 +4,9 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
+/* If true, will attempt to download and build netcdf-fortran. */
+/* #undef BUILD_FORTRAN */
+
 /* default file chunk cache nelems. */
 #define CHUNK_CACHE_NELEMS 1009
 
@@ -27,17 +30,23 @@
 /* default chunk size in bytes */
 #define DEFAULT_CHUNK_SIZE 4194304
 
-/* set this only when building a DLL under MinGW */
-/* #undef DLL_NETCDF */
+/* if true, enable CDF5 Support */
+/* #define ENABLE_CDF5 1 */
 
 /* if true, build DAP Client */
 /* #undef ENABLE_DAP */
 
+/* if true, build DAP4 Client */
+/* #undef ENABLE_DAP4 */
+
+/* if true, enable DAP group names */
+/* #undef ENABLE_DAP_GROUPS */
+
 /* if true, do remote tests */
 /* #undef ENABLE_DAP_REMOTE_TESTS */
 
-/* if true, run extra tests which may not work yet */
-/* #undef EXTRA_TESTS */
+/* if true, use _FillValue for NC_ERANGE data elements */
+/* #undef ERANGE_FILL */
 
 /* use HDF5 1.6 API */
 /* #undef H5_USE_16_API */
@@ -49,11 +58,17 @@
    */
 #define HAVE_ALLOCA_H 1
 
-/* Define to 1 if you have the <ctype.h> header file. */
-#define HAVE_CTYPE_H 1
+/* Is CURLINFO_RESPONSE_CODE defined */
+#define HAVE_CURLINFO_RESPONSE_CODE 1
 
 /* Is CURLOPT_KEYPASSWD defined */
 #define HAVE_CURLOPT_KEYPASSWD 1
+
+/* Is CURLOPT_PASSWORD defined */
+#define HAVE_CURLOPT_PASSWORD 1
+
+/* Is CURLOPT_USERNAME defined */
+#define HAVE_CURLOPT_USERNAME 1
 
 /* Define to 1 if you have the declaration of `isfinite', and to 0 if you
    don't. */
@@ -67,22 +82,8 @@
    */
 #define HAVE_DECL_ISNAN 1
 
-/* Define to 1 if you have the declaration of `signbit', and to 0 if you
-   don't. */
-#define HAVE_DECL_SIGNBIT 1
-
-/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
-   */
-#define HAVE_DIRENT_H 1
-
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
-
-/* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
-/* #undef HAVE_DOPRNT */
-
-/* Define to 1 if you have the <errno.h> header file. */
-#define HAVE_ERRNO_H 1
 
 /* Define to 1 if you have the <fcntl.h> header file. */
 #define HAVE_FCNTL_H 1
@@ -90,8 +91,14 @@
 /* Define to 1 if you have the `fsync' function. */
 #define HAVE_FSYNC 1
 
+/* Define to 1 if you have the <ftw.h> header file. */
+#define HAVE_FTW_H 1
+
 /* Define to 1 if you have the <getopt.h> header file. */
 #define HAVE_GETOPT_H 1
+
+/* Define to 1 if you have the `getpagesize' function. */
+#define HAVE_GETPAGESIZE 1
 
 /* Define to 1 if you have the `getrlimit' function. */
 #define HAVE_GETRLIMIT 1
@@ -99,14 +106,23 @@
 /* Define to 1 if you have the `gettimeofday' function. */
 #define HAVE_GETTIMEOFDAY 1
 
+/* Define to 1 if you have the `H5free_memory' function. */
+/* #undef HAVE_H5FREE_MEMORY */
+
 /* Define to 1 if you have the `H5Pget_fapl_mpio' function. */
 /* #undef HAVE_H5PGET_FAPL_MPIO */
 
 /* Define to 1 if you have the `H5Pget_fapl_mpiposix' function. */
 /* #undef HAVE_H5PGET_FAPL_MPIPOSIX */
 
+/* Define to 1 if you have the `H5Pset_all_coll_metadata_ops' function. */
+/* #undef HAVE_H5PSET_ALL_COLL_METADATA_OPS */
+
 /* Define to 1 if you have the `H5Pset_deflate' function. */
 /* #undef HAVE_H5PSET_DEFLATE */
+
+/* Define to 1 if you have the `H5Pset_libver_bounds' function. */
+/* #undef HAVE_H5PSET_LIBVER_BOUNDS */
 
 /* Define to 1 if you have the `H5Z_SZIP' function. */
 /* #undef HAVE_H5Z_SZIP */
@@ -114,14 +130,20 @@
 /* Define to 1 if you have the <hdf5.h> header file. */
 /* #undef HAVE_HDF5_H */
 
+/* Define to 1 if the system has the type `int64'. */
+/* #undef HAVE_INT64 */
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
 
-/* Define to 1 if you have the `curl' library (-lcurl). */
-#define HAVE_LIBCURL 1
-
 /* Define to 1 if you have the `df' library (-ldf). */
 /* #undef HAVE_LIBDF */
+
+/* Define to 1 if you have the <libgen.h> header file. */
+#define HAVE_LIBGEN_H 1
+
+/* Define to 1 if you have the `jpeg' library (-ljpeg). */
+/* #undef HAVE_LIBJPEG */
 
 /* Define to 1 if you have the `m' library (-lm). */
 #define HAVE_LIBM 1
@@ -144,11 +166,17 @@
 /* Define to 1 if you have the <malloc.h> header file. */
 /* #undef HAVE_MALLOC_H */
 
+/* Define to 1 if you have the `memmove' function. */
+#define HAVE_MEMMOVE 1
+
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the <mfhdf.h> header file. */
 /* #undef HAVE_MFHDF_H */
+
+/* Define to 1 if you have the `mkstemp' function. */
+#define HAVE_MKSTEMP 1
 
 /* Define to 1 if you have the `mktemp' function. */
 #define HAVE_MKTEMP 1
@@ -156,17 +184,17 @@
 /* Define to 1 if you have the `MPI_Comm_f2c' function. */
 /* #undef HAVE_MPI_COMM_F2C */
 
-/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
-/* #undef HAVE_NDIR_H */
+/* Define to 1 if you have the `mremap' function. */
+/* #undef HAVE_MREMAP */
 
-/* Define to 1 if the system has the type `ptrdiff_t'. */
-#define HAVE_PTRDIFF_T 1
+/* Define to 1 if you have the `random' function. */
+#define HAVE_RANDOM 1
 
-/* no rpc/types.h */
-/* #undef HAVE_RPC_TYPES_H */
+/* Define to 1 if the system has the type `schar'. */
+/* #undef HAVE_SCHAR */
 
-/* no rpc/xdr.h */
-/* #undef HAVE_RPC_XDR_H */
+/* Define to 1 if the system has the type `size_t'. */
+#define HAVE_SIZE_T 1
 
 /* Define to 1 if you have the `snprintf' function. */
 #define HAVE_SNPRINTF 1
@@ -177,9 +205,6 @@
 /* Define to 1 if you have the <stdarg.h> header file. */
 #define HAVE_STDARG_H 1
 
-/* Define to 1 if stdbool.h conforms to C99. */
-#define HAVE_STDBOOL_H 1
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
 
@@ -189,23 +214,8 @@
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
 
-/* Define to 1 if you have the `strcasecmp' function. */
-#define HAVE_STRCASECMP 1
-
-/* Define to 1 if you have the `strcat' function. */
-#define HAVE_STRCAT 1
-
-/* Define to 1 if you have the `strchr' function. */
-#define HAVE_STRCHR 1
-
-/* Define to 1 if you have the `strcpy' function. */
-#define HAVE_STRCPY 1
-
 /* Define to 1 if you have the `strdup' function. */
 #define HAVE_STRDUP 1
-
-/* Define to 1 if you have the `strerror' function. */
-#define HAVE_STRERROR 1
 
 /* Define to 1 if you have the <strings.h> header file. */
 #define HAVE_STRINGS_H 1
@@ -215,12 +225,6 @@
 
 /* Define to 1 if you have the `strlcat' function. */
 #define HAVE_STRLCAT 1
-
-/* Define to 1 if you have the `strrchr' function. */
-#define HAVE_STRRCHR 1
-
-/* Define to 1 if you have the `strtod' function. */
-#define HAVE_STRTOD 1
 
 /* Define to 1 if you have the `strtoll' function. */
 #define HAVE_STRTOLL 1
@@ -235,13 +239,11 @@
    `HAVE_STRUCT_STAT_ST_BLKSIZE' instead. */
 #define HAVE_ST_BLKSIZE 1
 
-/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
-   */
-/* #undef HAVE_SYS_DIR_H */
+/* Define to 1 if you have the `sysconf' function. */
+#define HAVE_SYSCONF 1
 
-/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
-   */
-/* #undef HAVE_SYS_NDIR_H */
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
 
 /* Define to 1 if you have the <sys/resource.h> header file. */
 #define HAVE_SYS_RESOURCE_H 1
@@ -255,11 +257,14 @@
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
 
-/* Define to 1 if you have <sys/wait.h> that is POSIX.1 compatible. */
-#define HAVE_SYS_WAIT_H 1
-
 /* Define to 1 if the system has the type `uchar'. */
 /* #undef HAVE_UCHAR */
+
+/* Define to 1 if the system has the type `uint'. */
+#define HAVE_UINT 1
+
+/* Define to 1 if the system has the type `uint64'. */
+/* #undef HAVE_UINT64 */
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1
@@ -267,11 +272,24 @@
 /* Define to 1 if the system has the type `unsigned long long int'. */
 /* #undef HAVE_UNSIGNED_LONG_LONG_INT */
 
-/* Define to 1 if you have the `vprintf' function. */
-#define HAVE_VPRINTF 1
+/* Define to 1 if the system has the type `ushort'. */
+#define HAVE_USHORT 1
 
-/* Define to 1 if the system has the type `_Bool'. */
-#define HAVE__BOOL 1
+/* if true, use collective metadata ops in parallel netCDF-4 */
+/* #undef HDF5_HAS_COLL_METADATA_OPS */
+
+/* if true, H5free_memory() will be used to free hdf5-allocated memory in
+   nc4file. */
+/* #undef HDF5_HAS_H5FREE */
+
+/* if true, netcdf4 file properties will be set using H5Pset_libver_bounds */
+/* #undef HDF5_HAS_LIBVER_BOUNDS */
+
+/* if true, hdf5 has parallelism enabled */
+/* #undef HDF5_PARALLEL */
+
+/* if true, include JNA bug fix */
+/* #undef JNA */
 
 /* do large file tests */
 /* #undef LARGE_FILE_TESTS */
@@ -279,57 +297,20 @@
 /* If true, turn on logging. */
 /* #undef LOGGING */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
 
 /* max size of the default per-var chunk cache. */
 #define MAX_DEFAULT_CACHE_SIZE 67108864
 
-/* type definition */
-/* #undef NCBYTE_T */
-
 /* min blocksize for posixio. */
 #define NCIO_MINBLOCKSIZE 256
-
-/* type definition */
-/* #undef NCSHORT_T */
-
-/* default */
-/* #undef NF_DOUBLEPRECISION_IS_C_DOUBLE */
-
-/* default */
-/* #undef NF_INT1_IS_C_SIGNED_CHAR */
-
-/* type thing */
-/* #undef NF_INT1_T */
-
-/* default */
-/* #undef NF_INT2_IS_C_SHORT */
-
-/* type thing */
-/* #undef NF_INT2_T */
-
-/* default */
-/* #undef NF_INT_IS_C_INT */
-
-/* default */
-/* #undef NF_REAL_IS_C_FLOAT */
 
 /* no IEEE float on this platform */
 /* #undef NO_IEEE_FLOAT */
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* do not build the netCDF version 2 API */
 /* #undef NO_NETCDF_2 */
-
-/* no stdlib.h */
-/* #undef NO_STDLIB_H */
-
-/* no sys_types.h */
-/* #undef NO_SYS_TYPES_H */
 
 /* Name of package */
 #define PACKAGE "netcdf"
@@ -341,7 +322,7 @@
 #define PACKAGE_NAME "netCDF"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "netCDF 4.1.3"
+#define PACKAGE_STRING "netCDF 4.6.1"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "netcdf"
@@ -350,7 +331,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.1.3"
+#define PACKAGE_VERSION "4.6.1"
+
+/* if true, NC_EINVALCOORDS check is more relaxed */
+/* #undef RELAX_COORD_BOUND */
+
+/* the testservers for remote tests. */
+#define REMOTETESTSERVERS "remotetest.unidata.ucar.edu,jetstream.unidata.ucar.edu"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -364,6 +351,9 @@
 /* The size of `long', as computed by sizeof. */
 #define SIZEOF_LONG 8
 
+/* The size of `long long', as computed by sizeof. */
+#define SIZEOF_LONG_LONG 8
+
 /* The size of `off_t', as computed by sizeof. */
 #define SIZEOF_OFF_T 8
 
@@ -372,6 +362,33 @@
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 8
+
+/* The size of `ssize_t', as computed by sizeof. */
+#define SIZEOF_SSIZE_T 8
+
+/* The size of `uchar', as computed by sizeof. */
+/* #undef SIZEOF_UCHAR */
+
+/* The size of `uint', as computed by sizeof. */
+#define SIZEOF_UINT 4
+
+/* The size of `unsigned char', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_CHAR 1
+
+/* The size of `unsigned int', as computed by sizeof. */
+/* #undef SIZEOF_UNSIGNED_INT */
+
+/* The size of `unsigned long long', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_LONG_LONG 8
+
+/* The size of `unsigned short int', as computed by sizeof. */
+/* #undef SIZEOF_UNSIGNED_SHORT_INT */
+
+/* The size of `ushort', as computed by sizeof. */
+#define SIZEOF_USHORT 2
+
+/* The size of `void*', as computed by sizeof. */
+#define SIZEOF_VOIDP 8
 
 /* If using the C implementation of alloca, define if you know the
    direction of stack growth for your system; otherwise it will be
@@ -387,20 +404,23 @@
 /* Place to put very large netCDF test files. */
 #define TEMP_LARGE "."
 
-/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
-#define TIME_WITH_SYS_TIME 1
-
-/* if true, build CDMREMOTE Client */
-/* #undef USE_CDMREMOTE */
+/* if true, enable CDF5 Support */
+/* #define USE_CDF5 1 */
 
 /* if true, build DAP Client */
 /* #undef USE_DAP */
 
+/* if true, include NC_DISKLESS code */
+#define USE_DISKLESS 1
+
 /* set this to use extreme numbers in tests */
 #define USE_EXTREME_NUMBERS 1
 
+/* if true, use ffio instead of posixio */
+/* #undef USE_FFIO */
+
 /* if true, include experimental fsync code */
-#define USE_FSYNC 1
+/* #undef USE_FSYNC */
 
 /* if true, use HDF4 too */
 /* #undef USE_HDF4 */
@@ -409,11 +429,20 @@
    it. */
 /* #undef USE_HDF4_FILE_TESTS */
 
+/* if true, use mmap for in-memory files */
+/* #undef USE_MMAP */
+
 /* if true, build netCDF-4 */
 /* #undef USE_NETCDF4 */
 
-/* if true, parallel netCDF-4 is in use */
+/* build the netCDF version 2 API */
+#define USE_NETCDF_2 1
+
+/* if true, pnetcdf or parallel netcdf-4 is in use */
 /* #undef USE_PARALLEL */
+
+/* if true, parallel netcdf-4 is in use */
+/* #undef USE_PARALLEL4 */
 
 /* if true, compile in parallel netCDF-4 based on MPI/IO */
 /* #undef USE_PARALLEL_MPIO */
@@ -424,14 +453,17 @@
 /* if true, parallel netCDF is used */
 /* #undef USE_PNETCDF */
 
+/* if true, use stdio instead of posixio */
+/* #undef USE_STDIO */
+
+/* if true, enable strict null byte header padding */
+/* #undef USE_STRICT_NULL_BYTE_HEADER_PADDING */
+
 /* if true, compile in szip compression in netCDF-4 variables */
 /* #undef USE_SZIP */
 
-/* if true, compile in zlib compression in netCDF-4 variables */
-/* #undef USE_ZLIB */
-
 /* Version number of package */
-#define VERSION "4.1.3"
+#define VERSION "4.6.1"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -445,31 +477,30 @@
 # endif
 #endif
 
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */
 
 /* Define for large files, on AIX-style hosts. */
 /* #undef _LARGE_FILES */
 
-/* Define to 1 if type `char' is unsigned and you are not using gcc.  */
-#ifndef __CHAR_UNSIGNED__
-/* # undef __CHAR_UNSIGNED__ */
-#endif
-
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */
-
-/* Turned on by netCDF configure. */
-/* #undef f2cFortran */
-
-/* Turned on by netCDF configure. */
-/* #undef gFortran */
 
 /* Define to `long int' if <sys/types.h> does not define. */
 /* #undef off_t */
 
-/* Turned on by netCDF configure. */
-/* #undef pgiFortran */
-
 /* Define to `unsigned int' if <sys/types.h> does not define. */
 /* #undef size_t */
+
+/* Define strcasecmp, snprintf on Win32 systems. */
+#ifdef _WIN32
+	#define strcasecmp _stricmp
+	#define snprintf _snprintf
+#endif
+
+#include "ncconfigure.h"


### PR DESCRIPTION
For netCDF, the header file is regenerated with netCDF 4.6.1 source code. 

For GraphicsMagick, the header file is regenerated with GraphicsMagick 1.3.25 source code, and modified to have the same options as the Win32 version. Linux config file is modified in the same manner.

I have tested the build on macOS 10.13 and ScientificLinux 6.