### PR TITLE
use malloc/free from hdf5

### DIFF
--- a/supportApp/hdf5Src/bshuf_h5filter.c
+++ b/supportApp/hdf5Src/bshuf_h5filter.c
@@ -144,7 +144,7 @@ size_t bshuf_h5_filter(unsigned int flags, size_t cd_nelmts,
     }
     size = nbytes_uncomp / elem_size;
 
-    out_buf = malloc(buf_size_out);
+    out_buf = H5allocate_memory(buf_size_out, false);
     if (out_buf == NULL) {
         PUSH_ERR("bshuf_h5_filter", H5E_CALLBACK, 
                 "Could not allocate output buffer.");
@@ -187,10 +187,10 @@ size_t bshuf_h5_filter(unsigned int flags, size_t cd_nelmts,
     if (err < 0) {
         sprintf(msg, "Error in bitshuffle with error code %d.", err);
         PUSH_ERR("bshuf_h5_filter", H5E_CALLBACK, msg);
-        free(out_buf);
+        H5free_memory(out_buf);
         return 0;
     } else {
-        free(*buf);
+        H5free_memory(*buf);
         *buf = out_buf;
         *buf_size = buf_size_out;
 


### PR DESCRIPTION
This fix avoids a crash on my tests on 64bit Scientific Linux 6.10. It tries to use hdf5 version malloc/free if the memory comes from or goes into hdf5 library.