### PR TITLE
Implicit function

### DIFF
--- a/supportApp/GraphicsMagickSrc/jp2/src/libjasper/base/jas_getopt.c
+++ b/supportApp/GraphicsMagickSrc/jp2/src/libjasper/base/jas_getopt.c
@@ -76,6 +76,7 @@
 
 #include "jasper/jas_getopt.h"
 #include "jasper/jas_math.h"
+#include "jasper/jas_debug.h"
 
 /******************************************************************************\
 * Global data.

--- a/supportApp/GraphicsMagickSrc/jp2/src/libjasper/include/jasper/jas_fix.h
+++ b/supportApp/GraphicsMagickSrc/jp2/src/libjasper/include/jasper/jas_fix.h
@@ -80,6 +80,7 @@
 
 #include <jasper/jas_config.h>
 #include <jasper/jas_types.h>
+#include <jasper/jas_debug.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_tsfb.c
+++ b/supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_tsfb.c
@@ -82,6 +82,12 @@
 #include "jpc_util.h"
 #include "jpc_math.h"
 
+int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+  int width, int height, int stride, int numlvls);
+
+int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+  int width, int height, int stride, int numlvls);
+
 void jpc_tsfb_getbands2(jpc_tsfb_t *tsfb, int locxstart, int locystart,
   int xstart, int ystart, int xend, int yend, jpc_tsfb_band_t **bands,
   int numlvls);

--- a/supportApp/GraphicsMagickSrc/webp/src/dec/alphadec.c
+++ b/supportApp/GraphicsMagickSrc/webp/src/dec/alphadec.c
@@ -15,6 +15,7 @@
 #include "./alphai.h"
 #include "./vp8i.h"
 #include "../enc/vp8li.h"
+#include "../dec/vp8li.h"
 #include "../dsp/dsp.h"
 #include "../utils/quant_levels_dec.h"
 #include "../utils/utils.h"


### PR DESCRIPTION
Since base 7.0.5, the compile flag `-Werror-implicit-function-declaration` has been adding, causing a few of the ADSupport modules to no longer build correctly.

This is a (hopefully) minimal fix to address these. I have compiled ADSupport with the flags
```
WITH_BIG_KEY:=YES
BIG_KEY_EXTERNAL:=NO
WITH_BITSHUFFLE:=YES
BITSHUFFLE_EXTERNAL:=NO
WITH_BLOSC:=YES
BLOSC_EXTERNAL:=NO
WITH_BUFFER_COMPAT:=YES
BUFFER_COMPAT_EXTERNAL:=NO
WITH_BZip2:=YES
BZip2_EXTERNAL:=NO
WITH_GRAPHICSMAGICK:=YES
GRAPHICSMAGICK_EXTERNAL:=NO
WITH_HarfBuzz:=YES
HarfBuzz_EXTERNAL:=NO
WITH_HDF4:=YES
HDF4_EXTERNAL:=NO
WITH_HDF5:=YES
HDF5_EXTERNAL:=NO
WITH_JPEG:=YES
JPEG_EXTERNAL:=NO
WITH_MAGICK_PLUS_PLUS:=YES
MAGICK_PLUS_PLUS_EXTERNAL:=NO
WITH_MODULES:=YES
MODULES_EXTERNAL:=NO
WITH_MXML:=YES
MXML_EXTERNAL:=NO
WITH_NETCDF:=YES
NETCDF_EXTERNAL:=NO
WITH_NEXUS:=YES
NEXUS_EXTERNAL:=NO
WITH_PNG:=YES
PNG_EXTERNAL:=NO
WITH_PRINT:=YES
PRINT_EXTERNAL:=NO
WITH_SZIP:=YES
SZIP_EXTERNAL:=NO
WITH_TIFF:=YES
TIFF_EXTERNAL:=NO
WITH_TIM_SORT:=YES
TIM_SORT_EXTERNAL:=NO
WITH_TRIO:=YES
TRIO_EXTERNAL:=NO
WITH_ZLIB:=YES
ZLIB_EXTERNAL:=NO
```
and with these changes, it builds correctly. I have admittedly only tested on linux-x86_64.