### PR TITLE
Do not enable IP6 when compiling with MinGW32

### DIFF
--- a/supportApp/xml2Src/os/WIN32/config.h
+++ b/supportApp/xml2Src/os/WIN32/config.h
@@ -116,8 +116,10 @@ static int isnan (double d) {
 #endif
 #endif
 
+#if !defined( __MINGW32__ )
 /* Support for IPv6 */
 #define SUPPORT_IP6 /**/
+#endif
 
 /* Some third-party libraries far from our control assume the following
    is defined, which it is not if we don't include windows.h. */


### PR DESCRIPTION
Related to issue: https://github.com/areaDetector/ADSupport/issues/34

Fixes by not defining IP6 when detected MinGW32 compiler. Tested and built without issue on CentOS 8.