### PR TITLE
Several fixes to build plugins with MinGW

### DIFF
--- a/supportApp/GraphicsMagickSrc/Magick++/lib/Magick++/Include.h
+++ b/supportApp/GraphicsMagickSrc/Magick++/lib/Magick++/Include.h
@@ -46,7 +46,7 @@ namespace MagickLib
 // Provide appropriate DLL imports/exports for Visual C++,
 // Borland C++Builder and MinGW builds.
 //
-#if (defined(WIN32) || defined(WIN64)) && !defined (__CYGWIN__) //&& !defined(__MINGW32__)
+#if (defined(WIN32) || defined(WIN64)) && !defined (__CYGWIN__) && !defined(__MINGW32__)
 # define MagickCplusPlusDLLSupported
 #endif
 #if defined(MagickCplusPlusDLLSupported)

--- a/supportApp/GraphicsMagickSrc/ttf/builds/windows/ftdebug.c
+++ b/supportApp/GraphicsMagickSrc/ttf/builds/windows/ftdebug.c
@@ -42,7 +42,7 @@
 
 
 #include <ft2build.h>
-#include FT_INTERNAL_DEBUG_H
+#include <freetype/internal/internal.h>
 
 
 #ifdef FT_DEBUG_LEVEL_ERROR

--- a/supportApp/hdf5Src/H5Zlz4.c
+++ b/supportApp/hdf5Src/H5Zlz4.c
@@ -10,7 +10,7 @@
 #include <assert.h>
 #include <stdio.h>
 #if defined(_WIN32)
-#include <Winsock2.h>
+#include <winsock2.h>
 #else
 #include <arpa/inet.h>
 #endif

--- a/supportApp/hdf5Src/os/WIN32/H5pubconf.h
+++ b/supportApp/hdf5Src/os/WIN32/H5pubconf.h
@@ -16,8 +16,9 @@
 #define H5_HAVE_WIN32_API 1
 
 /* Define if using a Windows compiler (i.e. Visual Studio) */
+#ifndef __MINGW32__
 #define H5_HAVE_VISUAL_STUDIO 1
-
+#endif
 /* Define if building universal (internal helper macro) */
 /* #undef H5_AC_APPLE_UNIVERSAL_BUILD */
 

--- a/supportApp/netCDFSrc/libdispatch/ddispatch.c
+++ b/supportApp/netCDFSrc/libdispatch/ddispatch.c
@@ -21,6 +21,10 @@ See LICENSE.txt for license information.
 #define getcwd _getcwd
 #endif
 
+#ifdef __MINGW32__
+#include <io.h>
+#include <direct.h>
+#endif
 
 /* Define vectors of zeros and ones for use with various nc_get_varX function*/
 size_t nc_sizevector0[NC_MAX_VAR_DIMS];

--- a/supportApp/netCDFSrc/libdispatch/dutil.c
+++ b/supportApp/netCDFSrc/libdispatch/dutil.c
@@ -220,7 +220,7 @@ NC_mktmp(const char* base)
 #else /* !HAVE_MKSTEMP */
     {
 #ifdef HAVE_MKTEMP
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
         /* Use _mktemp_s */
 	_mktemp_s(tmp,sizeof(tmp)-1);
 #else /*!_MSC_VER*/

--- a/supportApp/netCDFSrc/libsrc/memio.c
+++ b/supportApp/netCDFSrc/libsrc/memio.c
@@ -37,7 +37,9 @@
 #endif
 
 #ifndef HAVE_SSIZE_T
+#ifndef __MINGW32__
 typedef int ssize_t;
+#endif
 #endif
 
 #ifndef SEEK_SET

--- a/supportApp/netCDFSrc/libsrc/posixio.c
+++ b/supportApp/netCDFSrc/libsrc/posixio.c
@@ -42,7 +42,9 @@
 #endif
 
 #ifndef HAVE_SSIZE_T
+#ifndef __MINGW32__
 typedef int ssize_t;
+#endif
 #endif
 
 #ifndef SEEK_SET


### PR DESCRIPTION
When running with MinGW, building plugins fails without the following small changes - I've maintained it such that it isolates changes to when you are specifically using MinGW or when the change is superficial (like changing Winsock to winsock to avoid case sensitivity issues between cross compiling on linux versus direct on windows which doesn't care for case sensitivity).

This was built with a static setup but I also saw the same errors a few months back when using shared.