### PR TITLE
Fix typo in lz4_h5filter.h.

### DIFF
--- a/supportApp/hdf5Src/lz4_h5filter.h
+++ b/supportApp/hdf5Src/lz4_h5filter.h
@@ -17,7 +17,7 @@
 
 
 #ifndef LZ4_H5FILTER_H
-#define LZ5_H5FILTER_H
+#define LZ4_H5FILTER_H
 
 #define H5Z_class_t_vers 2
 #include "hdf5.h"


### PR DESCRIPTION
Similar fix upstream in [1].

[1] https://github.com/nexusformat/HDF5-External-Filter-Plugins/commit/5e6b70fc48c3c782dd0db06f32d2e2fc19cb4723