### PR TITLE
Fix nanohttp_stream build with external libxml2.

### DIFF
--- a/supportApp/xml2Src/Makefile
+++ b/supportApp/xml2Src/Makefile
@@ -123,6 +123,7 @@ ifeq ($(XML2_EXTERNAL),NO)
   LIB_SRCS += xmlstring.c
 
   nanohttp_stream_LIBS += xml2
+  nanohttp_stream_CFLAGS += -DIN_LIBXML
 
 else 
   nanohttp_stream_SYS_LIBS += xml2

--- a/supportApp/xml2Src/nanohttp_stream.c
+++ b/supportApp/xml2Src/nanohttp_stream.c
@@ -12,7 +12,6 @@
  */
 
 #define NEED_SOCKETS
-#define IN_LIBXML
 #include "libxml.h"
 
 #ifdef LIBXML_HTTP_ENABLED


### PR DESCRIPTION
Commit 2e167d2bd5a002b079589abb32b4e454e234355e defined IN_LIBXML unconditionally inside nanohttp_stream.c, which, when building on Linux with external libxml2, leads to multiple linking errors, since the redirections from "elfgcchack.h" are still included. The symbols will only be available when building the library inside ADSupport, so we can only define IN_LIBXML in that case. Since the added compiler flag will apply to all files, we can omit the "#define IN_LIBXML" line from them.

@MarkRivers, could you please check that this doesn't regress the build which commit 2e167d2bd5a002b079589abb32b4e454e234355e aimed to fix?