### PR TITLE
Fix release header formatting

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ the EXAMPLE_RELEASE_PATHS.local, EXAMPLE_RELEASE_LIBS.local, and EXAMPLE_RELEASE
 files respectively, in the configure/ directory of the appropriate release of the 
 [top-level areaDetector](https://github.com/areaDetector/areaDetector) repository.
 
- ## __R1-10 (May 26, 2021)__
+## __R1-10 (May 26, 2021)__
   * Changed the support for reading MJPEG streams in GraphicsMagickSrc and xml2Src.
     In R1-5 nanohttp.c and nanohppt.h in xml2Src were changed to support MJPEG streams.
     This had the undesired side-effect of being incompatible with the standard version
@@ -25,12 +25,12 @@ files respectively, in the configure/ directory of the appropriate release of th
     for MJPEG streaming.
   * This release now works with XML2_EXTERNAL=YES and WITH_GRAPHICSMAGICK=YES.
 
- ## __R1-9-1 (March 26, 2021)__
+## __R1-9-1 (March 26, 2021)__
   * Fixed compilation errors with EPICS base 7.0.5 which changed the use of undefined functions
     from being a warning to being an error.  There were a few files in GraphicsMagick that were missing
     the required header files.  There was also one file in the HDF5 support for vxWorks with this problem.
  
- ## __R1-9 (August 8, 2019)__
+## __R1-9 (August 8, 2019)__
   * Fixed memory allocation functions used in the blosc, lz4, bslz4, and JPEG HDF5 filters.
     In R1-8 it was consistently using H5allocate_memory() and H5free_memory, rather than malloc() and free().
     This prevented crashes when the compressors were called by NDFileHDF5.


### PR DESCRIPTION
Apparently, Sphinx understands the header token as a literal # after a list item if it is not the first character in the line. Thus, the blank before # in the R1-9 and 1-9-1 headers made them be rendered poorly.

This has been fixed for R1-9, R1-9-1 and R1-10 headers.

Let me know if this really fixes the issue.