### PR TITLE
adding video compression (h264)

### DIFF
--- a/supportApp/Makefile
+++ b/supportApp/Makefile
@@ -39,5 +39,7 @@ GraphicsMagickSrc_DEPEND_DIRS += tiffSrc zlibSrc xml2Src jpegSrc
 
 DIRS += cbfSrc
 
+DIRS += videoCompressionSrc
+
 include $(TOP)/configure/RULES_DIRS
 

--- a/supportApp/videoCompressionSrc/Makefile
+++ b/supportApp/videoCompressionSrc/Makefile
@@ -1,0 +1,38 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+
+ifeq ($(WITH_VC),YES)
+  ifeq ($(VC_EXTERNAL),NO)
+
+    LIBRARY_IOC = videoCompression
+    VC = $(TOP)/supportApp/videoCompressionSrc
+    USR_CFLAGS_Linux += -std=c99
+    USR_SYS_LIBS += avcodec
+    #USR_CFLAGS_WIN32 += -DLZ4_DLL_EXPORT=1
+    #USR_CFLAGS_WIN32 += -DBITSHUFFLE_DLL_EXPORT=1
+
+    INC += video_compression.h
+    LIB_SRCS += video_compression.c
+    
+    #SRC_DIRS += $(VC)/video_compression_tools
+    #SRC_DIRS += $(VC)/video_compression_tools/src
+    USR_INCLUDES += -I/usr/include/ffmpeg
+    #INC += packet_io.h
+    INC += streaming_vc.h
+    #INC += pgm.h
+    INC += codec_tools.h
+    #LIB_SRCS += packet_io.c
+    LIB_SRCS += streaming_vc.c
+    #LIB_SRCS += pgm.c
+    LIB_SRCS += codec_tools.c
+
+  endif # ($(VC_EXTERNAL),NO)
+endif # ($(WITH_VC),YES)
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE

--- a/supportApp/videoCompressionSrc/README
+++ b/supportApp/videoCompressionSrc/README
@@ -1,0 +1,7 @@
+Prerequisites:
+* ffmpeg needs to be installed. "yum install ffmpeg-devel"
+
+PVs:
+* $(P)$(R)QMinMax - 1 for least lossless compression, higher values for lossier compression
+* $(P)$(R)GOPSize - Group of picture size. 1 for frame-by-frame compression. Set to higher values for true video compression.
+

--- a/supportApp/videoCompressionSrc/codec_tools.c
+++ b/supportApp/videoCompressionSrc/codec_tools.c
@@ -13,7 +13,7 @@ AVCodecContext *c_d = 0;
 int count_d = 0;
 int mutex_initialized=0;
 
-CodecContext* vc_c=0;
+//CodecContext* vc_c=0;
 
 const AVCodec *codec;
 
@@ -88,6 +88,7 @@ AVFrame* packet_to_frame(AVCodecContext *c, AVPacket *pkt){
 	int i = 1;
 	frame = av_frame_alloc();
 	int ret = avcodec_send_packet(c, pkt);
+	if(c==0) printf("warning null context in packet_to_frame\n");
 	
 	do{
 		ret = avcodec_receive_frame(c, frame);
@@ -163,7 +164,7 @@ void reset_encoder_context(CodecContext* c){
 	avcodec_close(c_c);
 	avcodec_open2(c_c, codec, NULL);
 }
-void set_gop_size(CodecContext* c, int gop_size){
+void set_gop_size_(CodecContext* c, int gop_size){
 	AVCodecContext* c_c = c->c_c;
 	//maybe lock/unlock can go in reset function instead of every setter function?
 	pthread_mutex_t* mutex = &(c->mutex);
@@ -174,8 +175,8 @@ void set_gop_size(CodecContext* c, int gop_size){
 }
 //void set_q_min_max(CodecContext* c, int q){
 
-void set_q_min_max(int q){
-	CodecContext* c = vc_c;
+void set_q_min_max_(CodecContext* c, int q){
+	//CodecContext* c = vc_c;
 	if (c==0) {
 		printf("null context\n");
 		return;
@@ -196,6 +197,12 @@ void set_q_min_max(int q){
 	//avcodec_open2(c_c, codec, NULL);
 	reset_encoder_context(c);
 	pthread_mutex_unlock(mutex);
+}
+void set_q_min_max(void* c, int q){
+	set_q_min_max_((CodecContext*)c, q);
+}
+void set_gop_size(void* c, int q){
+	set_gop_size_((CodecContext*)c, q);
 }
 void re_init_encoder_context(CodecContext* c){
 	AVCodecContext* c_c = c->c_c;

--- a/supportApp/videoCompressionSrc/codec_tools.c
+++ b/supportApp/videoCompressionSrc/codec_tools.c
@@ -1,0 +1,222 @@
+/* Streaming video compression tools for libavcodec */
+/* Author: B.A. Sobhani <sobhaniba@ornl.gov> */
+
+#include <libavcodec/avcodec.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
+#include "streaming_vc.h"
+//#include "pgm.h"
+#include "codec_tools.h"
+
+AVCodecContext *c_c = 0; 
+int first = 1;
+AVCodecContext *c_d = 0; 
+int count_d = 0;
+
+
+const AVCodec *codec;
+
+AVCodecContext* init_decoder_context(){
+	AVCodecContext *c= NULL;
+	const AVCodec *codec;
+	avcodec_register_all();
+	codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+	c = avcodec_alloc_context3(codec);
+	avcodec_open2(c, codec, NULL);
+	return c;
+}
+
+AVCodecContext* init_encoder_context(int width, int height){
+	AVCodecContext *c= NULL;
+	avcodec_register_all();
+	codec = avcodec_find_encoder(AV_CODEC_ID_H264);
+	c = avcodec_alloc_context3(codec);
+	c->bit_rate = 400000;
+	c->width = width;
+	c->height = height;
+	//c->qmin = 1;
+	//c->qmax = 20;
+	c->time_base = (AVRational){1, 25};
+	c->framerate = (AVRational){25, 1};
+	//av_opt_set(c->priv_data, "crf", "1", AV_OPT_SEARCH_CHILDREN);
+	//av_opt_set(c->priv_data, "crf", "0", 0);
+	//av_opt_set(c->priv_data, "crf", "20", 0);
+	c->gop_size = 100;
+	//c->max_b_frames = 1;
+	c->max_b_frames = 0;
+	//c->pix_fmt = AV_PIX_FMT_YUV420P;
+	//c->pix_fmt = AV_PIX_FMT_YUV422P10;
+	c->pix_fmt = AV_PIX_FMT_YUV422P;
+	c->flags |= AV_CODEC_FLAG_QSCALE;
+
+	int ret = avcodec_open2(c, codec, NULL);
+
+	if (ret < 0) {
+		fprintf(stderr, "Could not open codec: %s\n", av_err2str(ret));
+		exit(1);
+	}
+	return c;
+}
+
+
+
+void buffer_to_packet(char* buffer, int size, AVPacket* pkt){
+	pkt->size = size;
+	pkt->data = (unsigned char*) malloc(sizeof(unsigned char)*size);
+	for(int i=0; i<size; ++i){
+		pkt->data[i] = buffer[i];
+	}
+}
+
+
+AVFrame* packet_to_frame(AVCodecContext *c, AVPacket *pkt){
+	
+	AVFrame* frame;
+	int i = 1;
+	frame = av_frame_alloc();
+	int ret = avcodec_send_packet(c, pkt);
+	
+	do{
+		ret = avcodec_receive_frame(c, frame);
+		++i;
+	} while(ret && i<10);
+	return frame;
+}
+
+
+
+int pts_i = 0;
+AVFrame* uncompressed_buffer_to_frame(AVCodecContext* c, char* buffer){
+	AVFrame* frame = av_frame_alloc();
+	av_frame_make_writable(frame);
+
+	frame->format = c->pix_fmt;
+	frame->width  = c->width;
+	frame->height = c->height;
+	frame->pts = pts_i;
+	pts_i++;
+	unsigned char* frame_buffer = (unsigned char*)malloc(sizeof(unsigned char)*3*frame->width*frame->height);
+	int ret = av_image_fill_arrays(frame->data, (int*) frame->linesize, frame_buffer, c->pix_fmt, c->width, c->height, 1);
+	//free(frame_buffer);
+	if (ret < 0) {
+		fprintf(stderr, "Could not allocate the video frame data\n");
+		exit(1);
+	}
+	for(int i=0; i<frame->width*frame->height; ++i){
+		frame->data[0][i] = (unsigned char) (buffer[i]);
+		frame->data[1][i] = (char)128;
+		frame->data[2][i] = (char)128;
+	}
+	return frame;
+}
+
+AVPacket* frame_to_packet(AVCodecContext *c, AVFrame* frame){
+	AVPacket *pkt = av_packet_alloc();
+	int ret = avcodec_send_frame(c, frame);
+	if (ret < 0) {
+		fprintf(stderr, "Error sending a frame for encoding\n");
+		exit(1);
+	}
+
+	while(ret >= 0){
+        	ret = avcodec_receive_packet(c, pkt);
+
+		if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+			return 0;
+		else if (ret < 0) {
+			fprintf(stderr, "Error during encoding\n");
+			exit(1);
+		}
+
+		return pkt;
+		//av_packet_unref(pkt);
+	}
+	return pkt;
+}
+
+void packet_to_buffer(AVPacket* pkt, char* buffer){
+	for(int i=0; i<pkt->size; ++i){
+		buffer[i] = pkt->data[i];
+	}
+}
+
+void frame_to_compressed_buffer(AVCodecContext* c, AVFrame* frame, char* buffer){
+	AVPacket* pkt = frame_to_packet(c, frame);
+	packet_to_buffer(pkt, buffer);
+}
+
+void reset_encoder_context(){
+	avcodec_close(c_c);
+	avcodec_open2(c_c, codec, NULL);
+}
+void set_gop_size(int gop_size){
+	c_c->gop_size = gop_size;
+	reset_encoder_context();
+}
+void set_q_min_max(int q){
+	printf("in set_q_min_max function\n");
+	//c_c->global_quality = quality;
+	//avcodec_close(c_c);
+	if(c_c==0){
+		printf("ERROR c_c is NULL!! could not set qminmax to %d\n", q);
+		return;
+	}
+	c_c->qmin = q;
+	c_c->qmax = q;
+	//avcodec_open2(c_c, codec, NULL);
+	reset_encoder_context();
+}
+void re_init_encoder_context(){
+	printf("inside re_init_encoder_context\n");
+	int width, height;
+	if(c_c!=0){
+		width = c_c->width;
+		height = c_c->height;
+		avcodec_close(c_c);
+	}
+	else{
+		printf("encoder cannot be reinitialized because it is not initialized\n");
+		return;
+	}
+	printf("initializing with width,height %d,%d\n", width, height); 
+	c_c = init_encoder_context(width, height); 
+}
+
+	
+//for later support of 16- or 32-bit images
+//void write_buffer_8(char* buffer, int i, int val){
+//	buffer[i] = val;
+//}
+//void write_buffer_16(char* buffer, int i, int val){
+//	char bytes[2];
+//	memcpy(bytes, &val, 2);
+//	buffer[2*i] = val;
+//	buffer[2*i+1] = 0;
+//}
+
+int frame_to_buffer(AVFrame* frame, char* buffer, int* width, int* height){
+	*width = frame->width;
+	*height = frame->height;
+	int pix_size = 1;
+
+	int b_i = 0;
+	for(int i=0; i<(frame->linesize[0])*(*height); ++i){
+		if(i%frame->linesize[0] < frame->width){
+			//for later support of 16- or 32-bit images
+			//if(pix_size==1){
+			//	write_buffer_8(buffer, b_i, frame->data[0][i]);
+			//}
+			//else if(pix_size==2){
+			//	write_buffer_16(buffer, b_i, frame->data[0][2*i]);
+			//}
+			buffer[b_i] = frame->data[0][i];
+			b_i++;
+		}
+	}
+	return (*width)*(*height)*pix_size;
+}
+
+
+
+
+

--- a/supportApp/videoCompressionSrc/codec_tools.c
+++ b/supportApp/videoCompressionSrc/codec_tools.c
@@ -12,6 +12,7 @@ AVCodecContext *c_c = 0;
 int first = 1;
 AVCodecContext *c_d = 0; 
 int count_d = 0;
+int mutex_initialized=0;
 
 
 const AVCodec *codec;
@@ -150,21 +151,27 @@ void reset_encoder_context(){
 	avcodec_open2(c_c, codec, NULL);
 }
 void set_gop_size(int gop_size){
+	//maybe lock/unlock can go in reset function instead of every setter function?
+	pthread_mutex_lock(&mutex);
 	c_c->gop_size = gop_size;
 	reset_encoder_context();
+	pthread_mutex_unlock(&mutex);
 }
 void set_q_min_max(int q){
+	pthread_mutex_lock(&mutex);
 	printf("in set_q_min_max function\n");
 	//c_c->global_quality = quality;
 	//avcodec_close(c_c);
 	if(c_c==0){
 		printf("ERROR c_c is NULL!! could not set qminmax to %d\n", q);
+		pthread_mutex_unlock(&mutex);
 		return;
 	}
 	c_c->qmin = q;
 	c_c->qmax = q;
 	//avcodec_open2(c_c, codec, NULL);
 	reset_encoder_context();
+	pthread_mutex_unlock(&mutex);
 }
 void re_init_encoder_context(){
 	printf("inside re_init_encoder_context\n");

--- a/supportApp/videoCompressionSrc/codec_tools.h
+++ b/supportApp/videoCompressionSrc/codec_tools.h
@@ -3,6 +3,7 @@
 
 #ifndef CODEC_TOOLS
 #define CODEC_TOOLS
+#include <pthread.h>
 AVCodecContext* init_decoder_context();
 AVCodecContext* init_encoder_context(int width, int height);
 void buffer_to_packet(char* buffer, int size, AVPacket* pkt);
@@ -17,6 +18,8 @@ void write_buffer_16(char* buffer, int i, int val);
 int frame_to_buffer(AVFrame* frame, char* buffer, int* width, int* height);
 void set_gop_size(int gop_size);
 void set_q_min_max(int q);
+pthread_mutex_t mutex;
+int mutex_initialized;
 
 extern AVCodecContext *c_c; 
 extern int first;

--- a/supportApp/videoCompressionSrc/codec_tools.h
+++ b/supportApp/videoCompressionSrc/codec_tools.h
@@ -14,7 +14,7 @@ typedef struct{
 	int mutex_initialized;
 } CodecContext;
 
-extern CodecContext* vc_c;
+//extern CodecContext* vc_c;
 
 
 CodecContext* init_decoder_context();
@@ -29,9 +29,10 @@ void re_init_encoder_context();
 void write_buffer_8(char* buffer, int i, int val);
 void write_buffer_16(char* buffer, int i, int val);
 int frame_to_buffer(AVFrame* frame, char* buffer, int* width, int* height);
-void set_gop_size(CodecContext* c, int gop_size);
+//void set_gop_size(CodecContext* c, int gop_size);
+void set_gop_size(void* c, int gop_size);
 //void set_q_min_max(CodecContext* c, int q);
-void set_q_min_max(int q);
+void set_q_min_max(void* c, int q);
 //pthread_mutex_t mutex;
 int mutex_initialized;
 

--- a/supportApp/videoCompressionSrc/codec_tools.h
+++ b/supportApp/videoCompressionSrc/codec_tools.h
@@ -1,0 +1,26 @@
+/* Streaming video compression tools for libavcodec */
+/* Author: B.A. Sobhani <sobhaniba@ornl.gov> */
+
+#ifndef CODEC_TOOLS
+#define CODEC_TOOLS
+AVCodecContext* init_decoder_context();
+AVCodecContext* init_encoder_context(int width, int height);
+void buffer_to_packet(char* buffer, int size, AVPacket* pkt);
+AVFrame* packet_to_frame(AVCodecContext *c, AVPacket *pkt);
+AVFrame* uncompressed_buffer_to_frame(AVCodecContext* c, char* buffer);
+AVPacket* frame_to_packet(AVCodecContext *c, AVFrame* frame);
+void packet_to_buffer(AVPacket* pkt, char* buffer);
+void frame_to_compressed_buffer(AVCodecContext* c, AVFrame* frame, char* buffer);
+void re_init_encoder_context();
+void write_buffer_8(char* buffer, int i, int val);
+void write_buffer_16(char* buffer, int i, int val);
+int frame_to_buffer(AVFrame* frame, char* buffer, int* width, int* height);
+void set_gop_size(int gop_size);
+void set_q_min_max(int q);
+
+extern AVCodecContext *c_c; 
+extern int first;
+extern AVCodecContext *c_d; 
+extern int count_d;
+
+#endif

--- a/supportApp/videoCompressionSrc/codec_tools.h
+++ b/supportApp/videoCompressionSrc/codec_tools.h
@@ -34,7 +34,8 @@ void set_gop_size(void* c, int gop_size);
 //void set_q_min_max(CodecContext* c, int q);
 void set_q_min_max(void* c, int q);
 //pthread_mutex_t mutex;
-int mutex_initialized;
+//int mutex_initialized;
+AVCodecContext* init_av_encoder_context(int width, int height);
 
 
 //extern AVCodecContext *c_c; 

--- a/supportApp/videoCompressionSrc/codec_tools.h
+++ b/supportApp/videoCompressionSrc/codec_tools.h
@@ -4,8 +4,21 @@
 #ifndef CODEC_TOOLS
 #define CODEC_TOOLS
 #include <pthread.h>
-AVCodecContext* init_decoder_context();
-AVCodecContext* init_encoder_context(int width, int height);
+#include <libavcodec/avcodec.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
+
+typedef struct{
+	AVCodecContext *c_c;
+	pthread_mutex_t mutex;
+	int mutex_initialized;
+} CodecContext;
+
+extern CodecContext* vc_c;
+
+
+CodecContext* init_decoder_context();
+CodecContext* init_encoder_context(int width, int height);
 void buffer_to_packet(char* buffer, int size, AVPacket* pkt);
 AVFrame* packet_to_frame(AVCodecContext *c, AVPacket *pkt);
 AVFrame* uncompressed_buffer_to_frame(AVCodecContext* c, char* buffer);
@@ -16,12 +29,14 @@ void re_init_encoder_context();
 void write_buffer_8(char* buffer, int i, int val);
 void write_buffer_16(char* buffer, int i, int val);
 int frame_to_buffer(AVFrame* frame, char* buffer, int* width, int* height);
-void set_gop_size(int gop_size);
+void set_gop_size(CodecContext* c, int gop_size);
+//void set_q_min_max(CodecContext* c, int q);
 void set_q_min_max(int q);
-pthread_mutex_t mutex;
+//pthread_mutex_t mutex;
 int mutex_initialized;
 
-extern AVCodecContext *c_c; 
+
+//extern AVCodecContext *c_c; 
 extern int first;
 extern AVCodecContext *c_d; 
 extern int count_d;

--- a/supportApp/videoCompressionSrc/streaming_vc.c
+++ b/supportApp/videoCompressionSrc/streaming_vc.c
@@ -48,8 +48,9 @@ int compress_buffer(CodecContext* c, char* source, int x_size, int y_size, char*
 	pthread_mutex_unlock(mutex);
 	return r;
 }
+AVCodecContext* init_av_decoder_context();
 int decompress_buffer(char* buffer_in, int size_in, char* buffer_out, int* width, int* height){
-	if(c_d==0) c_d = init_decoder_context();
+	if(c_d==0) c_d = init_av_decoder_context();
 	AVPacket* pkt;
 	pkt = av_packet_alloc();
 	pkt->pts = count_d;

--- a/supportApp/videoCompressionSrc/streaming_vc.c
+++ b/supportApp/videoCompressionSrc/streaming_vc.c
@@ -6,12 +6,16 @@
 #include <libavutil/opt.h>
 #include "codec_tools.h"
 extern int mutex_initialized;
-int compress_buffer(char* source, int x_size, int y_size, char* dest){
+int compress_buffer(CodecContext* c, char* source, int x_size, int y_size, char* dest){
+	AVCodecContext* c_c = c->c_c;
+	pthread_mutex_t* mutex = &(c->mutex);
+	//if(c->mutex_initialized==0){
 	if(mutex_initialized==0){
-		pthread_mutex_init(&mutex, NULL);
+		pthread_mutex_init(mutex, NULL);
+		c->mutex_initialized=1;
 		mutex_initialized=1;
 	}
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(mutex);
 	int pix_size = 1;
 	int uncompressed_size = pix_size*x_size*y_size;
 	if(c_c==0){
@@ -28,12 +32,12 @@ int compress_buffer(char* source, int x_size, int y_size, char* dest){
 	free(frame->data[0]);
 	av_frame_free(&frame);
 	if(pkt==0){
-		pthread_mutex_unlock(&mutex);
+		pthread_mutex_unlock(mutex);
 		return -1;
 	}
 	//Fail if compressed size is larger than uncompressed - to prevent memory being written out of range
 	if(pkt->size > uncompressed_size){
-		pthread_mutex_unlock(&mutex);
+		pthread_mutex_unlock(mutex);
 		return -1;
 	}
 	packet_to_buffer(pkt, dest);
@@ -41,7 +45,7 @@ int compress_buffer(char* source, int x_size, int y_size, char* dest){
 	av_packet_free(&pkt);
 	//av_packet_unref(pkt);
 	//return pkt->size;
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(mutex);
 	return r;
 }
 int decompress_buffer(char* buffer_in, int size_in, char* buffer_out, int* width, int* height){

--- a/supportApp/videoCompressionSrc/streaming_vc.c
+++ b/supportApp/videoCompressionSrc/streaming_vc.c
@@ -19,11 +19,13 @@ int compress_buffer(CodecContext* c, char* source, int x_size, int y_size, char*
 	int pix_size = 1;
 	int uncompressed_size = pix_size*x_size*y_size;
 	if(c_c==0){
-		c_c = init_encoder_context(x_size, y_size); 
+		//c_c = init_encoder_context(x_size, y_size); 
+		c_c = init_av_encoder_context(x_size, y_size); 
 	}
 	else if(c_c->width!=x_size || c_c->height!=y_size){
 		avcodec_close(c_c);
-		c_c = init_encoder_context(x_size, y_size); 
+		//c_c = init_encoder_context(x_size, y_size); 
+		c_c = init_av_encoder_context(x_size, y_size); 
 	}
 		
 	AVPacket* pkt;

--- a/supportApp/videoCompressionSrc/streaming_vc.c
+++ b/supportApp/videoCompressionSrc/streaming_vc.c
@@ -1,0 +1,60 @@
+/* Streaming video compression high level functions */
+/* Author: B.A. Sobhani <sobhaniba@ornl.gov> */
+
+#include <libavcodec/avcodec.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
+#include "codec_tools.h"
+
+int compress_buffer(char* source, int x_size, int y_size, char* dest){
+	int pix_size = 1;
+	int uncompressed_size = pix_size*x_size*y_size;
+	if(c_c==0){
+		c_c = init_encoder_context(x_size, y_size); 
+	}
+	else if(c_c->width!=x_size || c_c->height!=y_size){
+		avcodec_close(c_c);
+		c_c = init_encoder_context(x_size, y_size); 
+	}
+		
+	AVPacket* pkt;
+	AVFrame* frame = uncompressed_buffer_to_frame(c_c, source);
+	pkt = frame_to_packet(c_c, frame);
+	free(frame->data[0]);
+	av_frame_free(&frame);
+	if(pkt==0){
+		return -1;
+	}
+	//Fail if compressed size is larger than uncompressed - to prevent memory being written out of range
+	if(pkt->size > uncompressed_size){
+		return -1;
+	}
+	packet_to_buffer(pkt, dest);
+	int r = pkt->size;
+	av_packet_free(&pkt);
+	//av_packet_unref(pkt);
+	//return pkt->size;
+	return r;
+}
+int decompress_buffer(char* buffer_in, int size_in, char* buffer_out, int* width, int* height){
+	if(c_d==0) c_d = init_decoder_context();
+	AVPacket* pkt;
+	pkt = av_packet_alloc();
+	pkt->pts = count_d;
+	buffer_to_packet(buffer_in, size_in, pkt);
+	AVFrame* frame = packet_to_frame(c_d, pkt);
+	int pt = frame->pict_type;
+	if(first==1 && pt != AV_PICTURE_TYPE_I){
+		av_frame_free(&frame);
+		av_packet_free(&pkt);
+		return -1;
+	}
+	first = 0;
+	count_d++;
+	int decompressed_size = frame_to_buffer(frame, buffer_out, width, height);
+	//free(frame->data[0]);
+	av_frame_free(&frame);
+	av_packet_free(&pkt);
+	return decompressed_size;
+}
+

--- a/supportApp/videoCompressionSrc/streaming_vc.h
+++ b/supportApp/videoCompressionSrc/streaming_vc.h
@@ -1,9 +1,10 @@
 /* Streaming video compression high level functions */
 /* Author: B.A. Sobhani <sobhaniba@ornl.gov> */
 
+#include "codec_tools.h"
 //AVFrame* packet_to_frame(AVCodecContext *c, AVPacket *pkt);
 int decompress_buffer(char* buffer_in, int size_in, char* buffer_out, int* width, int* height);
 //int compress_buffer(char* source, int source_size, char* dest);
-int compress_buffer(char* source, int x_size, int y_size, char* dest);
+int compress_buffer(CodecContext* c, char* source, int x_size, int y_size, char* dest);
 
 void re_init_encoder_context();

--- a/supportApp/videoCompressionSrc/streaming_vc.h
+++ b/supportApp/videoCompressionSrc/streaming_vc.h
@@ -1,0 +1,9 @@
+/* Streaming video compression high level functions */
+/* Author: B.A. Sobhani <sobhaniba@ornl.gov> */
+
+//AVFrame* packet_to_frame(AVCodecContext *c, AVPacket *pkt);
+int decompress_buffer(char* buffer_in, int size_in, char* buffer_out, int* width, int* height);
+//int compress_buffer(char* source, int source_size, char* dest);
+int compress_buffer(char* source, int x_size, int y_size, char* dest);
+
+void re_init_encoder_context();

--- a/supportApp/videoCompressionSrc/video_compression.c
+++ b/supportApp/videoCompressionSrc/video_compression.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+//#include "packet_io.h"
+#include "streaming_vc.h"
+
+
+int H264_compress(const char* source, char* dest, int x_size, int y_size)
+{
+	int num_bytes = compress_buffer(source, x_size, y_size, dest);
+	return num_bytes;
+}
+
+void reset_context(){
+	printf("inside reset context function\n");
+	re_init_encoder_context();
+}
+
+int H264_decompress(const char* source, char* dest, int originalSize)
+{
+
+        int width, height;
+        decompress_buffer(source, originalSize, dest, &width, &height);
+	return width*height;
+
+}
+
+
+

--- a/supportApp/videoCompressionSrc/video_compression.c
+++ b/supportApp/videoCompressionSrc/video_compression.c
@@ -6,10 +6,16 @@
 
 //int H264_compress(CodecContext* c, const char* source, char* dest, int x_size, int y_size)
 extern CodecContext* vc_c;
-int H264_compress(const char* source, char* dest, int x_size, int y_size)
+
+int vc_size(){
+	return sizeof(CodecContext);
+}
+
+int H264_compress(void** p_vc_c, const char* source, char* dest, int x_size, int y_size)
 {
-	if(vc_c==0) vc_c = init_encoder_context(x_size, y_size);
-	int num_bytes = compress_buffer(vc_c, source, x_size, y_size, dest);
+	CodecContext** p_c = (CodecContext**) p_vc_c;
+	if(*p_c==0) *p_c = init_encoder_context(x_size, y_size);
+	int num_bytes = compress_buffer(*p_c, source, x_size, y_size, dest);
 	return num_bytes;
 }
 

--- a/supportApp/videoCompressionSrc/video_compression.c
+++ b/supportApp/videoCompressionSrc/video_compression.c
@@ -4,9 +4,12 @@
 #include "streaming_vc.h"
 
 
+//int H264_compress(CodecContext* c, const char* source, char* dest, int x_size, int y_size)
+extern CodecContext* vc_c;
 int H264_compress(const char* source, char* dest, int x_size, int y_size)
 {
-	int num_bytes = compress_buffer(source, x_size, y_size, dest);
+	if(vc_c==0) vc_c = init_encoder_context(x_size, y_size);
+	int num_bytes = compress_buffer(vc_c, source, x_size, y_size, dest);
 	return num_bytes;
 }
 

--- a/supportApp/videoCompressionSrc/video_compression.h
+++ b/supportApp/videoCompressionSrc/video_compression.h
@@ -7,12 +7,15 @@ extern "C" {
 //#include "codec_tools.h"
 
 //int H264_compress(CodecContext* c, const char* source, char* dest, int x_size, int y_size);
-int H264_compress(const char* source, char* dest, int x_size, int y_size);
+//int H264_compress(const char* source, char* dest, int x_size, int y_size);
+int H264_compress(void** p_vc_c, const char* source, char* dest, int x_size, int y_size);
 
 
 void reset_context();
-void set_gop_size(int gop_size);
-void set_q_min_max(int q);
+//void set_gop_size(int gop_size);
+void set_gop_size(void* c, int gop_size);
+void set_q_min_max(void* c, int q);
+int vc_size();
 
 //int LZ4_compressBound(int inputSize);
 #if defined (__cplusplus)

--- a/supportApp/videoCompressionSrc/video_compression.h
+++ b/supportApp/videoCompressionSrc/video_compression.h
@@ -4,7 +4,9 @@
 #if defined (__cplusplus)
 extern "C" {
 #endif
+//#include "codec_tools.h"
 
+//int H264_compress(CodecContext* c, const char* source, char* dest, int x_size, int y_size);
 int H264_compress(const char* source, char* dest, int x_size, int y_size);
 
 

--- a/supportApp/videoCompressionSrc/video_compression.h
+++ b/supportApp/videoCompressionSrc/video_compression.h
@@ -1,0 +1,20 @@
+#ifndef VIDEO_COMPRESSION_H
+#define VIDEO_COMPRESSION_H
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+int H264_compress(const char* source, char* dest, int x_size, int y_size);
+
+
+void reset_context();
+void set_gop_size(int gop_size);
+void set_q_min_max(int q);
+
+//int LZ4_compressBound(int inputSize);
+#if defined (__cplusplus)
+}
+#endif
+
+#endif


### PR DESCRIPTION
Starting pull request for video compression (h264) support. Not close to being perfect, but getting the process started so that it does not linger.

Basic functionality works and seems stable on the machines I tested it on. Achieves lower compression sizes with higher quality than existing codecs for some types of image sequences. For example, if the differences between frames is consistently small, like at SNS beamlines where neutron events accumulate on an image.

To compile, set:

WITH_VC=YES
VC_EXTERNAL=NO

To use, select "H264" from $(P)$(R)Compressor.

Tuning PVs:
* $(P)$(R)QMinMax - 1 for least lossless compression, higher values for lossier compression
* $(P)$(R)GOPSize - Group of picture size. 1 for frame-by-frame compression. Set to higher values for true video compression.