### PR TITLE
Fix GCC condition check

### DIFF
--- a/supportApp/hdf5_hlSrc/H5LTanalyze.c
+++ b/supportApp/hdf5_hlSrc/H5LTanalyze.c
@@ -1,4 +1,4 @@
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >=2                           
+#if defined __GNUC__ && 402 <= __GNUC__ * 100 + __GNUC_MINOR__
 #pragma GCC diagnostic ignored "-Wconversion"                     
 #pragma GCC diagnostic ignored "-Wimplicit-function-declaration"  
 #pragma GCC diagnostic ignored "-Wlarger-than="                   
@@ -900,7 +900,7 @@ char *H5LTyytext;
 #include "H5LTparse.h"
 
 /* Turn off suggest const attribute warning in gcc */
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >=2 
+#if defined __GNUC__ && 402 <= __GNUC__ * 100 + __GNUC_MINOR__
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 #endif 
 

--- a/supportApp/hdf5_hlSrc/H5LTparse.c
+++ b/supportApp/hdf5_hlSrc/H5LTparse.c
@@ -1,4 +1,4 @@
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >=2                           
+#if defined __GNUC__ && 402 <= __GNUC__ * 100 + __GNUC_MINOR__
 #pragma GCC diagnostic ignored "-Wconversion"                     
 #pragma GCC diagnostic ignored "-Wimplicit-function-declaration"  
 #pragma GCC diagnostic ignored "-Wlarger-than="                   


### PR DESCRIPTION
This fixes failing builds for versions of gcc such as 14.1 (where major is > 4 but minor < 2)