### PR TITLE
Fixing incompatible pointer assignment that causes build on RHEL 10 t…

### DIFF
--- a/supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c
+++ b/supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c
@@ -96,7 +96,7 @@
 
 int jpc_ft_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
   int stride);
-int jpc_ft_synthesize(int *a, int xstart, int ystart, int width, int height,
+int jpc_ft_synthesize(jpc_fix_t *a, int xstart, int ystart, int width, int height,
   int stride);
 
 int jpc_ns_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
@@ -1592,7 +1592,7 @@ int jpc_ft_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
 
 }
 
-int jpc_ft_synthesize(int *a, int xstart, int ystart, int width, int height,
+int jpc_ft_synthesize(jpc_fix_t *a, int xstart, int ystart, int width, int height,
   int stride)
 {
 	int numrows = height;

--- a/supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.h
+++ b/supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.h
@@ -75,6 +75,7 @@
 \******************************************************************************/
 
 #include "jasper/jas_seq.h"
+#include "jpc_fix.h"
 
 /******************************************************************************\
 * Constants.
@@ -101,8 +102,8 @@ any particular platform.  Hopefully, it is not too unreasonable, however. */
 #endif
 
 typedef struct {
-	int (*analyze)(int *, int, int, int, int, int);
-	int (*synthesize)(int *, int, int, int, int, int);
+	int (*analyze)(jpc_fix_t *, int, int, int, int, int);
+	int (*synthesize)(jpc_fix_t *, int, int, int, int, int);
 	double *lpenergywts;
 	double *hpenergywts;
 } jpc_qmfb2d_t;

--- a/supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_tsfb.c
+++ b/supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_tsfb.c
@@ -82,10 +82,10 @@
 #include "jpc_util.h"
 #include "jpc_math.h"
 
-int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, jpc_fix_t *a, int xstart, int ystart,
   int width, int height, int stride, int numlvls);
 
-int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, jpc_fix_t *a, int xstart, int ystart,
   int width, int height, int stride, int numlvls);
 
 void jpc_tsfb_getbands2(jpc_tsfb_t *tsfb, int locxstart, int locystart,
@@ -133,7 +133,7 @@ int jpc_tsfb_analyze(jpc_tsfb_t *tsfb, jas_seq2d_t *a)
 	  jas_seq2d_height(a), jas_seq2d_rowstep(a), tsfb->numlvls - 1) : 0;
 }
 
-int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, jpc_fix_t *a, int xstart, int ystart,
   int width, int height, int stride, int numlvls)
 {
 	if (width > 0 && height > 0) {
@@ -160,7 +160,7 @@ int jpc_tsfb_synthesize(jpc_tsfb_t *tsfb, jas_seq2d_t *a)
 	  jas_seq2d_height(a), jas_seq2d_rowstep(a), tsfb->numlvls - 1) : 0;
 }
 
-int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, jpc_fix_t *a, int xstart, int ystart,
   int width, int height, int stride, int numlvls)
 {
 	if (numlvls > 0) {


### PR DESCRIPTION
…o fail

w/o this change, on RHEL 10, we get:

```
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c:288:9: error: initialization of ‘int (*)(int *, int,  int,  int,  int,  int)’ from incompatible pointer type ‘int (*)(jpc_fix_t *, int,  int,  int,  int,  int)’ {aka ‘int (*)(long int *, int,  int,  int,  int,  int)’} [-Wincompatible-pointer-types]
  288 |         jpc_ft_analyze,
      |         ^~~~~~~~~~~~~~
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c:288:9: note: (near initialization for ‘jpc_ft_qmfb2d.analyze’)
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c:295:9: error: initialization of ‘int (*)(int *, int,  int,  int,  int,  int)’ from incompatible pointer type ‘int (*)(jpc_fix_t *, int,  int,  int,  int,  int)’ {aka ‘int (*)(long int *, int,  int,  int,  int,  int)’} [-Wincompatible-pointer-types]
  295 |         jpc_ns_analyze,
      |         ^~~~~~~~~~~~~~
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c:295:9: note: (near initialization for ‘jpc_ns_qmfb2d.analyze’)
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c:296:9: error: initialization of ‘int (*)(int *, int,  int,  int,  int,  int)’ from incompatible pointer type ‘int (*)(jpc_fix_t *, int,  int,  int,  int,  int)’ {aka ‘int (*)(long int *, int,  int,  int,  int,  int)’} [-Wincompatible-pointer-types]
  296 |         jpc_ns_synthesize,
      |         ^~~~~~~~~~~~~~~~~
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c:296:9: note: (near initialization for ‘jpc_ns_qmfb2d.synthesize’)
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c: In function ‘jpc_ft_synthesize’:
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c:1607:18: error: assignment to ‘jpc_fix_t *’ {aka ‘long int *’} from incompatible pointer type ‘int *’ [-Wincompatible-pointer-types]
 1607 |         startptr = &a[0];
      |                  ^
../../../../../../supportApp/GraphicsMagickSrc/jp2/src/libjasper/jpc/jpc_qmfb.c:1615:18: error: assignment to ‘jpc_fix_t *’ {aka ‘long int *’} from incompatible pointer type ‘int *’ [-Wincompatible-pointer-types]
 1615 |         startptr = &a[0];
      |                  ^
make[6]: *** [/epics/utils/epics-rpm-config/BUILD/base/configure/RULES_BUILD:260: jpc_qmfb.o] Error 1
```

The reason this is necessary is as follows:

The implementation of the jpc_{ft,ns}_{synthesize,analyze} functions assume its
first argument is a pointer to jpc_fix_t, as all of them will copy it to a
local variable called startptr of this type. Because on some systems jpc_fix_t
is a long int, we might get a compilation error, as it happens on RHEL 10.

Change the type of the jpc_ft_synthesize argument so there is not an
incompatible pointer assignment. Changing the signature of `analyze` and
`synthesize` fields in the jpc_qmfb2d_t struct is also needed because the
aforementioned functions will be assigned to them. Similarly,
jpc_tsfb_synthesize2() calls `synthesize` but mistakenly declares its forwarded
argument as int*.

The same fix was applied as part of this commit: https://github.com/jasper-software/jasper/commit/d743f7e0ad901dc3419fc1042939a5454de96c16 in the upstream repository.

Once merged, could we make a new tag/released version?